### PR TITLE
Reimplement the JSON related model protocols.

### DIFF
--- a/SocialTodo.xcodeproj/project.pbxproj
+++ b/SocialTodo.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		E9C91C1F1FD31CD600ADFEF9 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = E9C91C1E1FD31CD600ADFEF9 /* .swiftlint.yml */; };
 		E9C91C271FD31D9600ADFEF9 /* SocialTodoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C91C261FD31D9600ADFEF9 /* SocialTodoTests.swift */; };
 		E9C91C351FD31DC700ADFEF9 /* SocialTodoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C91C341FD31DC700ADFEF9 /* SocialTodoUITests.swift */; };
+		E9C91C401FD3274300ADFEF9 /* JSONItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C91C3F1FD3274300ADFEF9 /* JSONItem.swift */; };
+		E9C91C421FD327BB00ADFEF9 /* JSONObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C91C411FD327BB00ADFEF9 /* JSONObject.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +56,8 @@
 		E9C91C341FD31DC700ADFEF9 /* SocialTodoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialTodoUITests.swift; sourceTree = "<group>"; };
 		E9C91C361FD31DC700ADFEF9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E9C91C3C1FD31E3200ADFEF9 /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
+		E9C91C3F1FD3274300ADFEF9 /* JSONItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONItem.swift; sourceTree = "<group>"; };
+		E9C91C411FD327BB00ADFEF9 /* JSONObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObject.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +170,8 @@
 		E9C91C191FD31C1300ADFEF9 /* ModelProtocols */ = {
 			isa = PBXGroup;
 			children = (
+				E9C91C3F1FD3274300ADFEF9 /* JSONItem.swift */,
+				E9C91C411FD327BB00ADFEF9 /* JSONObject.swift */,
 			);
 			path = ModelProtocols;
 			sourceTree = "<group>";
@@ -419,6 +425,8 @@
 			files = (
 				C7DE93CD1FD28906006F73F0 /* ViewController.swift in Sources */,
 				C7DE93CB1FD28906006F73F0 /* AppDelegate.swift in Sources */,
+				E9C91C401FD3274300ADFEF9 /* JSONItem.swift in Sources */,
+				E9C91C421FD327BB00ADFEF9 /* JSONObject.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -586,10 +594,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = CH64A7AV3T;
 				INFOPLIST_FILE = SocialTodo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = me.saatvikarya.SocialTodo;
+				PRODUCT_BUNDLE_IDENTIFIER = me.saatvikarya.SocialTodoB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -602,10 +610,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = CH64A7AV3T;
 				INFOPLIST_FILE = SocialTodo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = me.saatvikarya.SocialTodo;
+				PRODUCT_BUNDLE_IDENTIFIER = me.saatvikarya.SocialTodoB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/SocialTodo/ModelProtocols/JSONItem.swift
+++ b/SocialTodo/ModelProtocols/JSONItem.swift
@@ -1,0 +1,28 @@
+/**
+ # JSON Item
+
+ This protocol represents an object that is to be later converted to JSON.
+ All implementing classes therefore are able to be coded and decoded into JSON.
+*/
+import Foundation
+
+protocol JSONItem: Equatable, Codable {
+  typealias ObjectID = String
+  /* An optional objectID parameter on the list element — If a JSONListElement is created within the application, it will not have an ID until
+  it is uploaded to the server, and having objectID equal to nil will suggest to the server that this is a new Todo. On the otherhand, if the Todo
+  is not new and already exsists in the database, having objectID set to the database's keyvalue for the JSONListElement object will allow the server
+  to identify what object it should change. */
+  var objectID: ObjectID? { get }
+}
+
+extension JSONItem {
+  /**
+    Asserts that two JSONListElements are equal if they have the same objectID.
+    If either element does not have an objectID, the expression returns false.
+
+    - Returns: A Bool that asserts that both JSONListElement's objectID's are not nil and they have equal objectID's.
+  */
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.objectID != nil && lhs.objectID == rhs.objectID
+  }
+}

--- a/SocialTodo/ModelProtocols/JSONObject.swift
+++ b/SocialTodo/ModelProtocols/JSONObject.swift
@@ -1,0 +1,60 @@
+/**
+ # JSON List
+
+ A JSONItem that holds other JSONItems. Since it is a JSONItem itself, it also conforms to the Codable protocol.
+*/
+
+protocol JSONObject: JSONItem {
+  associatedtype Item: JSONItem
+  // The jsonObjects variable represents the collection of JSONItems it holds.
+  var jsonObjects: [Item] { get set }
+  /* An optional objectID parameter on the list element — If a JSONListElement is created within the application, it will not have an ID until
+   it is uploaded to the server, and having objectID equal to nil will suggest to the server that this is a new Todo. On the otherhand, if the Todo
+   is not new and already exsists in the database, having objectID set to the database's keyvalue for the JSONListElement object will allow the server
+   to identify what object it should change. */
+  var objectID: JSONItem.ObjectID? { get }
+}
+
+extension JSONObject {
+  mutating public func add(item: Item) {
+    jsonObjects.append(item)
+  }
+
+  mutating public func add(items: [Item]) {
+    for item in items {
+      jsonObjects.append(item)
+    }
+  }
+
+  /**
+   Removes the current element at an index in the list and then reindexes the list.
+
+   Warning: If one element is removed, Swift will automatically
+   reindex the others, so further removes should not be permitted
+   until tableView recieves new, properly indexed elements
+   */
+  mutating public func remove(index: Int) {
+    jsonObjects.remove(at: index)
+  }
+
+  mutating public func remove(element: Item) -> Bool {
+    for index in 0...jsonObjects.count where element == jsonObjects[index] {
+      jsonObjects.remove(at: index)
+      return true
+    }
+    return false
+  }
+
+  public func getElement(index: Int) -> Item {
+    return jsonObjects[index]
+  }
+
+  // This should always return an array of strings
+  public func getElements() -> [Item] {
+    return jsonObjects
+  }
+
+  mutating public func empty() {
+    jsonObjects = []
+  }
+}


### PR DESCRIPTION
JSONObject and it's related properteies were renamed so that their name did not implicitly suggest an implementation. Also, JSONItem was made more generic, and now JSONObject is a JSONItem itself.